### PR TITLE
Fix WebAssembly threading by enabling cross origin headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,11 @@ RUN npm run build
 # ------------ Étape 2 : image finale avec nginx non-root -------------------------
 FROM nginxinc/nginx-unprivileged:alpine
 
-# Copie des fichiers
+# Copie des fichiers générés
 COPY --from=build /app/dist /usr/share/nginx/html
+
+# Configuration nginx personnalisée (COEP/COOP pour WebAssembly threadé)
+COPY nginx.conf /etc/nginx/nginx.conf
 
 # Exposition du port 8080 (port par défaut de nginx-unprivileged)
 EXPOSE 8080

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,16 @@
+worker_processes 1;
+events { worker_connections 1024; }
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+    sendfile        on;
+    server {
+        listen 8080;
+        root /usr/share/nginx/html;
+        add_header Cross-Origin-Embedder-Policy "require-corp" always;
+        add_header Cross-Origin-Opener-Policy "same-origin" always;
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- serve SPA with custom nginx config
- enforce COOP/COEP headers for WebAssembly threading

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683fe4a47ffc83269fc56d803b73d2f8